### PR TITLE
Problemas con intsvy.select.merge con TIMSS 1995/2003 G8

### DIFF
--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -55,6 +55,9 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
   files.select <- lapply(files.all, function(y) sapply(countries, function(x) y[substr(y, 
   nchar(y)+config$input$cnt_part[1], nchar(y)+config$input$cnt_part[2])==tolower(x)])) 
   # no blanks, no home instrument, otherwise delete, see 4g function
+           
+  # Whenever file.select has countries with not directories, filter them out.
+  files.select <- sapply(files.all, function(x) Filter(function(var) length(var) != 0, x))  
   
   # Remove cases for no home instruments
   # only if home is specified

--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -97,8 +97,7 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
       }
       
       # Read the home data
-      suppressWarnings(suppressMessages(home.data <-                           # Read [[2]] home
-                                          lapply(files.select[[config$input$home]], function(y) 
+      suppressWarnings(suppressMessages(home.data <- lapply(files.select[[config$input$home]], function(y) # Read [[2]] home
                                             read.spss(y, to.data.frame=TRUE, use.value.labels=use.labels))))
       
       # Making sure all variable names are in upper case
@@ -117,9 +116,9 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
         stop('cannot locate school data files')
       }
       
-      suppressWarnings(suppressMessages(school.data <-          # Read [[2]] school
-                      lapply(files.select[[config$input$school]], function(y) 
-                      read.spss(y, to.data.frame=T))))
+      suppressWarnings(suppressMessages(school.data <- lapply(files.select[[config$input$school]],
+                                                              function(y) # Read [[2]] school
+                                                              read.spss(y, to.data.frame=T, use.value.labels = use.labels))))
 
       # Making sure all variable names are in upper case
       school.data <- lapply(school.data, function(data) { 

--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -57,7 +57,7 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
   # no blanks, no home instrument, otherwise delete, see 4g function
            
   # Whenever file.select has countries with not directories, filter them out.
-  files.select <- sapply(files.all, function(x) Filter(function(var) length(var) != 0, x))  
+  files.select <- lapply(files.all, function(x) Filter(function(var) length(var) != 0, x))  
   
   # Remove cases for no home instruments
   # only if home is specified

--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -67,46 +67,70 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
     }
   }
   
-  #
-  # PREPARING
-  #
-
-  # Student achievement and background data, 
-  # needed also if school is non-missing
-  if (!missing(student) | !missing(school)) {
-    if (!missing(student) & is.null(files.select[[config$input$student]])) {
-      stop('cannot locate student data files')
+    #
+    # PREPARING
+    #
+    
+    # Student achievement and background data, 
+    # needed also if school is non-missing
+    if (!missing(student) | !missing(school)) {
+      if (!missing(student) & is.null(files.select[[config$input$student]])) {
+        stop('cannot locate student data files')
+      }
+      
+      suppressWarnings(suppressMessages(junk0 <- lapply(files.select[[config$input$student]], function(y) 
+        read.spss(y, to.data.frame=TRUE, use.value.labels=use.labels))))
+      
+      junk0 <- lapply(junk0, function(data) { 
+       names(data) <- toupper(names(data))
+        data
+        })
+      
+      student.data <- do.call('rbind', lapply(junk0, function(x) x[, unique(c(config$input$student_colnames1,
+                      grep(config$input$student_pattern, names(x), value=TRUE), student, config$input$student_colnames2))]))
     }
     
-    suppressWarnings(suppressMessages(junk0 <- lapply(files.select[[config$input$student]], function(y) 
-      read.spss(y, to.data.frame=TRUE, use.value.labels=use.labels))))
-    student.data <- do.call('rbind', lapply(junk0, function(x) x[, unique(c(config$input$student_colnames1,
-      grep(config$input$student_pattern, names(x), value=TRUE), student, config$input$student_colnames2))]))
-  }
-  
-  # Home background data
-  if (!missing(home)) {
-    if (is.null(files.select[[config$input$home]])) {
-      stop('cannot locate home background data files')
+    # Home background data
+    if (!missing(home)) {
+      if (is.null(files.select[[config$input$home]])) {
+        stop('cannot locate home background data files')
+      }
+      
+      # Read the home data
+      suppressWarnings(suppressMessages(home.data <-                           # Read [[2]] home
+                                          lapply(files.select[[config$input$home]], function(y) 
+                                            read.spss(y, to.data.frame=TRUE, use.value.labels=use.labels))))
+      
+      # Making sure all variable names are in upper case
+      home.data <- lapply(home.data, function(data) { 
+        names(data) <- toupper(names(data))
+        data
+      })
+      
+      home.data <- do.call("rbind", lapply(home.data, function(x)             # Merge [[2]] home
+        x[, unique(c(config$input$school_colnames, home))]))
     }
     
-    suppressWarnings(suppressMessages(home.data <- do.call("rbind",                          # Merge [[2]] home
-              lapply(files.select[[config$input$home]], function(y) 
-                read.spss(y, to.data.frame=TRUE, use.value.labels=use.labels)[, unique(c(           # Each dataset
-                  config$input$home_colnames, home))]))))                                     # Selected
-  }
-  
-  # School data
-  if (!missing(school)) {
-    if (is.null(files.select[[config$input$school]])) {
-      stop('cannot locate school data files')
-    }
+    # School data
+    if (!missing(school)) {
+      if (is.null(files.select[[config$input$school]])) {
+        stop('cannot locate school data files')
+      }
+      
+      suppressWarnings(suppressMessages(school.data <-          # Read [[2]] school
+                      lapply(files.select[[config$input$school]], function(y) 
+                      read.spss(y, to.data.frame=T))))
 
-    suppressWarnings(suppressMessages(school.data <- do.call("rbind",                      # Merge [[2]] school
-           lapply(files.select[[config$input$school]], function(y) 
-             read.spss(y, to.data.frame=T)[unique(c(config$input$school_colnames, school))]))))    # Selected
-  }
-  
+      # Making sure all variable names are in upper case
+      school.data <- lapply(school.data, function(data) { 
+        names(data) <- toupper(names(data))
+        data
+      })
+      
+      school.data <- do.call("rbind", lapply(school.data, function(x) # Merge [[2]] home
+        x[, unique(c(config$input$school_colnames, school))]))
+    }
+   
   # Teacher data
   if (!missing(teacher)) {
     if (is.null(files.select[[config$input$teacher[1]]]) | is.null(files.select[[config$input$teacher[2]]])) {

--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -110,7 +110,7 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
       })
       
       home.data <- do.call("rbind", lapply(home.data, function(x)             # Merge [[2]] home
-        x[, unique(c(config$input$school_colnames, home))]))
+        x[, unique(c(config$input$home_colnames, home))]))
     }
     
     # School data


### PR DESCRIPTION
Hola Dani,

He estado trabajando con los datos del TIMSS y me he encontrado unos pequeños problems con la función intsvy.select.merge. Si te parecen validos, los aceptas.

Trabajando con TIMSS 1995 G8, había intentado algo tan simple como:
`timssg8.select.merge(folder = folder, student = c("BSBGEDUM", "BSBGEDUF"))`
donde había un problema que la función no encontraba algunos países en el directorio. En el código fuente después de definir `file.select` en la linea 60, si ves el contenido de `file.select`, hay dos países que no se pudieron obtener el directorio (BGR y ZAF). No se porque ocurre eso pero añadí las lines 58-60 donde filtro los directorios que un length != 0. Luego de correrlo, ya funciona.

Otro problema:
Trabajando con TIMSS 2007 G8, corriendo un código como este:
`timssg8.select.merge(folder = folder, student = c("BSBGMFED", "BSBGFMED"))`
me decía que habian `undefined columns` es decir, que algunas variables no se encontraban. Me fui al código fuente y resulta que después de leer las bases SPSS en las lineas 84-85, si corres esta linea: `sapply(junk0, function(x) all(tolower(names(x) == names(x))))` te das cuenta que Austria (el segundo país en la lista) tiene todos los nombres en lower case mientras que todos los otros en upper case. Esto estaba causando que no se pudieran encontrar las variables.

Arregle esto asegurándome que todos los nombres de las variables estaban en upper case con la linea 87-90 (pero tuve que desglosar el código que ya tenías por eso parece que he cambiado mucho). Como prevención, aplique lo mismo para el `home.data` y el `school.data` section.
Habría que aplicarlo para el teacher data, algo que haré cuando tenga tiempo.
 