### PR TITLE
Filter countries that weren't read correctly

### DIFF
--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -55,6 +55,9 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
   files.select <- lapply(files.all, function(y) sapply(countries, function(x) y[substr(y, 
   nchar(y)+config$input$cnt_part[1], nchar(y)+config$input$cnt_part[2])==tolower(x)])) 
   # no blanks, no home instrument, otherwise delete, see 4g function
+           
+  # Whenever file.select has countries with not directories, filter them out.
+  files.select <- lapply(files.all, function(x) Filter(function(var) length(var) != 0, x))  
   
   # Remove cases for no home instruments
   # only if home is specified


### PR DESCRIPTION
Hi,

Working with the TIMSS data I found a small problem with the function `intsvy.select.merge`. If you believe this is worthwhile, accept it.

Working with TIMSS 1995 G8, I tried something as simple as: `timssg8.select.merge(folder = folder, student = c("BSBGEDUM", "BSBGEDUF"))` and the function was having problems finding all countries in the directory. I went to the source code of the function and after defining `file.select` in line 55, the contents of the object has two countries which are missing (BGR and ZAG). I'm not sure why they are missing, but having those two countries prevented the function from working correctly. I added lines 58-60 where I simply filter the countries that were read correctly.
 