### PR TITLE
Filter countries that weren't read correctly - part 2

### DIFF
--- a/R/intsvy.select.merge.R
+++ b/R/intsvy.select.merge.R
@@ -56,6 +56,9 @@ function(folder=getwd(), countries, student=c(), home, school, teacher, use.labe
   nchar(y)+config$input$cnt_part[1], nchar(y)+config$input$cnt_part[2])==tolower(x)])) 
   # no blanks, no home instrument, otherwise delete, see 4g function
 
+  # Filter directories which have length 0
+  files.select <- lapply(files.select, function(x) Filter(function(var) length(var) != 0, x))
+  
   # Remove cases for no home instruments
   # only if home is specified
   if (!missing(home)) {


### PR DESCRIPTION
I found the issue with https://github.com/eldafani/intsvy/pull/3

It was actually a typo within `lapply`. In the previous PR I was using `files.all` instead of `files.select`.

You can that it works now with all of these examples:
http://users.ox.ac.uk/~educ0279/pirls2011.html