### PR TITLE
Generalising default functions to use BRRreps

### DIFF
--- a/R/intsvy.mean.pv.R
+++ b/R/intsvy.mean.pv.R
@@ -36,7 +36,12 @@ function(pvnames, by, data, export=FALSE, name= "output", folder=getwd(), config
       MEAN.m <- mean(PV.mean)
       SD.m <- mean(PV.sd)
       
-      cc = 1/20
+      if(length(config$parameters$BRRreps == 1) & is.numeric(config$parameters$BRRreps)){
+          cc<- 1/(config$parameters$BRRreps*(1-0.5)^2)	
+      } else {
+          cc<- 1/20
+          warning("default value for BRR reps (80) used, set this in your config")	
+      }
       if (config$parameters$weights == "mixed_piaac") {
         cntName <- as.character(unique(data[,config$variables$countryID]))[1]
         cc <- piaacReplicationScheme[cntName,"c"]

--- a/R/intsvy.reg.pv.R
+++ b/R/intsvy.reg.pv.R
@@ -48,7 +48,13 @@ intsvy.reg.pv <-
       stat.tot <- apply(coe.tot, 1, mean)
 
       # Sampling error (variance within)
-      var.w <- apply(0.05*sapply(lapply(1:config$parameters$PVreps, function(pv)
+      if(length(config$parameters$BRRreps == 1) & is.numeric(config$parameters$BRRreps)){
+          cc<- 1/(config$parameters$BRRreps*(1-0.5)^2)	
+      } else {
+          cc<- 1/20
+          warning("default value for BRR reps (80) used, set this in your config")	
+      }
+      var.w <- apply(cc*sapply(lapply(1:config$parameters$PVreps, function(pv)
                     (coe.rep[[pv]]-coe.tot[,pv])^2), function(e) apply(e, 1, sum)), 1, mean)
 
       # Imputation error (variance between)


### PR DESCRIPTION
consider generalising default functions (e.g., intsvy.mean|reg etc) to use BRRreps to calculate constant used in estimating variance rather than hard coding to 80 (constant = 1/20). This provides flexibility to users extended intsvy to use with other international studies.
